### PR TITLE
Modify aggregate call to support strict mode

### DIFF
--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 /// @author Michael Elliot <mike@makerdao.com>
 /// @author Joshua Levine <joshua@makerdao.com>
 /// @author Nick Johnson <arachnid@notdot.net>
+/// @author Bogdan Dumitru <bogdan@bowd.io>
 
 contract Multicall {
     struct Call {
@@ -16,8 +17,9 @@ contract Multicall {
       bytes data;
 
     }
-    function aggregate(Call[] memory calls, bool strict) public returns (uint256 blockNumber, Return[] memory returnData) {
+    function aggregate(Call[] memory calls, bool strict) public returns (uint256 blockNumber, bytes32 blockHash, Return[] memory returnData) {
         blockNumber = block.number;
+        blockHash = blockhash(block.number);
         returnData = new Return[](calls.length);
         for(uint256 i = 0; i < calls.length; i++) {
             (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -11,13 +11,20 @@ contract Multicall {
         address target;
         bytes callData;
     }
-    function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
+    struct Return {
+      bool success;
+      bytes data;
+
+    }
+    function aggregate(Call[] memory calls, bool strict) public returns (uint256 blockNumber, Return[] memory returnData) {
         blockNumber = block.number;
-        returnData = new bytes[](calls.length);
+        returnData = new Return[](calls.length);
         for(uint256 i = 0; i < calls.length; i++) {
             (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
-            require(success);
-            returnData[i] = ret;
+            if (strict) {
+              require(success);
+            }
+            returnData[i] = Return(success, ret);
         }
     }
     // Helper functions

--- a/src/Multicall.t.sol
+++ b/src/Multicall.t.sol
@@ -10,7 +10,12 @@ contract Store {
     function get() public view returns (uint256) { return val; }
     function getAnd10() public view returns (uint256, uint256) { return (val, 10); }
     function getAdd(uint256 _val) public view returns (uint256) { return val + _val; }
+    function getFailing(uint256 _val) public view returns (uint256) {
+      require(false);
+      return val + _val;
+    } 
 }
+
 
 // We inherit from Multicall rather than deploy an instance because solidity
 // can't return dynamically sized byte arrays from external contracts
@@ -39,13 +44,15 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("get()");
 
-        (, bytes[] memory _returnData) = aggregate(_calls);
+        (, Return[] memory _returnData) = aggregate(_calls, true);
 
-        bytes memory _word = _returnData[0];
+        bytes memory _word = _returnData[0].data;
+        bool _success = _returnData[0].success;
         uint256 _returnVal;
         assembly { _returnVal := mload(add(0x20, _word)) }
 
         assertEq(_returnVal, 123);
+        assert(_success);
     }
 
     function test_multi_call_single_return_no_args() public {
@@ -58,10 +65,12 @@ contract MulticallTest is DSTest, Multicall {
         _calls[1].target = address(storeB);
         _calls[1].callData = abi.encodeWithSignature("get()");
 
-        (, bytes[] memory _returnData) = aggregate(_calls);
+        (, Return[] memory _returnData) = aggregate(_calls, true);
 
-        bytes memory _wordA = _returnData[0];
-        bytes memory _wordB = _returnData[1];
+        bool _successA = _returnData[0].success;
+        bool _successB = _returnData[1].success;
+        bytes memory _wordA = _returnData[0].data;
+        bytes memory _wordB = _returnData[1].data;
         uint256 _returnValA;
         uint256 _returnValB;
         assembly { _returnValA := mload(add(0x20, _wordA)) }
@@ -69,6 +78,8 @@ contract MulticallTest is DSTest, Multicall {
 
         assertEq(_returnValA, 123);
         assertEq(_returnValB, 321);
+        assert(_successA);
+        assert(_successB);
     }
 
     function test_single_call_single_return_single_arg() public {
@@ -78,13 +89,15 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
 
-        (, bytes[] memory _returnData) = aggregate(_calls);
+        (, Return[] memory _returnData) = aggregate(_calls, true);
 
-        bytes memory _word = _returnData[0];
+        bytes memory _word = _returnData[0].data;
+        bool _success = _returnData[0].success;
         uint256 _returnVal;
         assembly { _returnVal := mload(add(0x20, _word)) }
 
         assertEq(_returnVal, 124);
+        assert(_success);
     }
 
     function test_multi_call_single_return_single_arg() public {
@@ -97,10 +110,12 @@ contract MulticallTest is DSTest, Multicall {
         _calls[1].target = address(storeB);
         _calls[1].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
 
-        (, bytes[] memory _returnData) = aggregate(_calls);
+        (, Return[] memory _returnData) = aggregate(_calls, true);
 
-        bytes memory _wordA = _returnData[0];
-        bytes memory _wordB = _returnData[1];
+        bool _successA = _returnData[0].success;
+        bool _successB = _returnData[1].success;
+        bytes memory _wordA = _returnData[0].data;
+        bytes memory _wordB = _returnData[1].data;
         uint256 _returnValA;
         uint256 _returnValB;
         assembly { _returnValA := mload(add(0x20, _wordA)) }
@@ -108,6 +123,8 @@ contract MulticallTest is DSTest, Multicall {
 
         assertEq(_returnValA, 124);
         assertEq(_returnValB, 322);
+        assert(_successA);
+        assert(_successB);
     }
 
     function test_single_call_multi_return_no_args() public {
@@ -117,9 +134,10 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("getAnd10()");
 
-        (, bytes[] memory _returnData) = aggregate(_calls);
+        (, Return[] memory _returnData) = aggregate(_calls, true);
 
-        bytes memory _words = _returnData[0];
+        bool _success = _returnData[0].success;
+        bytes memory _words = _returnData[0].data;
         uint256 _returnValA1;
         uint256 _returnValA2;
         assembly { _returnValA1 := mload(add(0x20, _words)) }
@@ -127,7 +145,59 @@ contract MulticallTest is DSTest, Multicall {
 
         assertEq(_returnValA1, 123);
         assertEq(_returnValA2, 10);
+        assert(_success);
+    }
 
+    function testFail_single_call_with_failure_in_strict_mode() public {
+        storeA.set(123);
+
+        Call[] memory _calls = new Call[](1);
+        _calls[0].target = address(storeA);
+        _calls[0].callData = abi.encodeWithSignature("getFailing()");
+
+        aggregate(_calls, true);
+    }
+
+    function test_single_call_with_failure() public {
+        storeA.set(123);
+
+        Call[] memory _calls = new Call[](1);
+        _calls[0].target = address(storeA);
+        _calls[0].callData = abi.encodeWithSignature("getFailing()");
+
+        (, Return[] memory _returnData) = aggregate(_calls, false);
+
+        bool _success = _returnData[0].success;
+        bytes memory _words = _returnData[0].data;
+
+        assert(_success == false);
+        assertEq0(_words, "");
+    }
+
+    function test_multi_call_with_one_failure() public {
+        storeA.set(123);
+        storeB.set(123);
+
+        Call[] memory _calls = new Call[](2);
+        _calls[0].target = address(storeA);
+        _calls[0].callData = abi.encodeWithSignature("getFailing()");
+        _calls[1].target = address(storeB);
+        _calls[1].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
+
+        (, Return[] memory _returnData) = aggregate(_calls, false);
+
+        bool _successA = _returnData[0].success;
+        bytes memory _wordA = _returnData[0].data;
+
+        bool _successB = _returnData[1].success;
+        bytes memory _wordB = _returnData[1].data;
+        uint256 _returnValB;
+        assembly { _returnValB := mload(add(0x20, _wordB)) }
+
+        assert(_successA == false);
+        assert(_successB);
+        assertEq0(_wordA, "");
+        assertEq(_returnValB, 124);
     }
 
     function test_helpers() public {

--- a/src/Multicall.t.sol
+++ b/src/Multicall.t.sol
@@ -44,7 +44,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("get()");
 
-        (, Return[] memory _returnData) = aggregate(_calls, true);
+        (,, Return[] memory _returnData) = aggregate(_calls, true);
 
         bytes memory _word = _returnData[0].data;
         bool _success = _returnData[0].success;
@@ -65,7 +65,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[1].target = address(storeB);
         _calls[1].callData = abi.encodeWithSignature("get()");
 
-        (, Return[] memory _returnData) = aggregate(_calls, true);
+        (,, Return[] memory _returnData) = aggregate(_calls, true);
 
         bool _successA = _returnData[0].success;
         bool _successB = _returnData[1].success;
@@ -89,7 +89,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
 
-        (, Return[] memory _returnData) = aggregate(_calls, true);
+        (,, Return[] memory _returnData) = aggregate(_calls, true);
 
         bytes memory _word = _returnData[0].data;
         bool _success = _returnData[0].success;
@@ -110,7 +110,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[1].target = address(storeB);
         _calls[1].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
 
-        (, Return[] memory _returnData) = aggregate(_calls, true);
+        (,, Return[] memory _returnData) = aggregate(_calls, true);
 
         bool _successA = _returnData[0].success;
         bool _successB = _returnData[1].success;
@@ -134,7 +134,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("getAnd10()");
 
-        (, Return[] memory _returnData) = aggregate(_calls, true);
+        (,, Return[] memory _returnData) = aggregate(_calls, true);
 
         bool _success = _returnData[0].success;
         bytes memory _words = _returnData[0].data;
@@ -165,7 +165,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[0].target = address(storeA);
         _calls[0].callData = abi.encodeWithSignature("getFailing()");
 
-        (, Return[] memory _returnData) = aggregate(_calls, false);
+        (,, Return[] memory _returnData) = aggregate(_calls, false);
 
         bool _success = _returnData[0].success;
         bytes memory _words = _returnData[0].data;
@@ -184,7 +184,7 @@ contract MulticallTest is DSTest, Multicall {
         _calls[1].target = address(storeB);
         _calls[1].callData = abi.encodeWithSignature("getAdd(uint256)", 1);
 
-        (, Return[] memory _returnData) = aggregate(_calls, false);
+        (,, Return[] memory _returnData) = aggregate(_calls, false);
 
         bool _successA = _returnData[0].success;
         bytes memory _wordA = _returnData[0].data;


### PR DESCRIPTION
The original contract was requiring that all encompassed calls succeed. 
I don't need such a strict requirement but I do need to know which calls succeeded and which failed, therefore, I have changed the return value to a struct that holds both the return state and data and I've removed the `require` if the strict argument isn't true.